### PR TITLE
Separate unsafe and runtime/cgo (resolves tailscale/depaware#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ https://github.com/tailscale/tailscale/blob/main/cmd/tailscaled/depaware.txt
 
 Then you and others can easily see what your dependencies are, how
 they vary by operating system (the letters L(inux), D(arwin),
-W(indows) in the left column), and whether they use unsafe/cgo (bomb
-icon).
+W(indows) in the left column), and whether they use (U)nsafe or runtime/(C)go.
 
 Then you hook it up to your CI so it's a build breakage if they're not up to date:
 


### PR DESCRIPTION
Tested on a few personal projects, and go version:
`go version go1.23.5 linux/amd64`

I replaced the bomb emoji with two columns (U/C) to start, but if there's a different format preferred, happy to change it around. 